### PR TITLE
Add new compiler defaults and mock-chain improvements

### DIFF
--- a/.changeset/breezy-students-draw.md
+++ b/.changeset/breezy-students-draw.md
@@ -1,0 +1,5 @@
+---
+"@fleet-sdk/mock-chain": minor
+---
+
+Add `MockChain.clearUTxOSet()` method.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,6 +6,5 @@
   "linked": [],
   "access": "public",
   "baseBranch": "master",
-  "updateInternalDependencies": "patch",
-  "ignore": ["@fleet-sdk/compiler"]
+  "updateInternalDependencies": "patch"
 }

--- a/.changeset/seven-zoos-own.md
+++ b/.changeset/seven-zoos-own.md
@@ -1,0 +1,5 @@
+---
+"@fleet-sdk/compiler": minor
+---
+
+Set `ErgoTree` v1 as default output.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "npm-run-all": "^4.1.5",
     "open-cli": "^7.2.0",
     "picocolors": "^1.0.0",
-    "sigmastate-js": "^0.2.0",
+    "sigmastate-js": "^0.2.1",
     "prettier": "^3.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@fleet-sdk/common": "workspace:^",
     "@fleet-sdk/core": "workspace:^",
-    "sigmastate-js": "^0.2.0"
+    "sigmastate-js": "^0.2.1"
   },
   "scripts": {
     "build": "run-p build:*",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fleet-sdk/compiler",
-  "version": "0.1.0-alpha.0",
+  "version": "0.0.0",
   "description": "Sigma.JS powered ErgoScript compiler.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -1,4 +1,4 @@
-import { assert, ergoTreeHeaderFlags, isEmpty, isHex, Network } from "@fleet-sdk/common";
+import { assert, ergoTreeHeaderFlags, isEmpty, isHex } from "@fleet-sdk/common";
 import { ISigmaType, SConstant } from "@fleet-sdk/core";
 import {
   SigmaCompilerNamedConstantsMap,
@@ -8,29 +8,46 @@ import {
 } from "sigmastate-js/main";
 import { CompilerOutput } from "./compilerOutput";
 
-export type CompilerOptions = {
+type CompilerOptionsBase = {
+  version?: number;
   map?: NamedConstantsMap;
   segregateConstants?: boolean;
-  includeSize?: boolean;
-  network?: Network;
 };
+
+export type CompilerOptionsForErgoTreeV0 = CompilerOptionsBase & {
+  version?: 0;
+  includeSize?: boolean;
+};
+
+export type CompilerOptionsForErgoTreeV1 = CompilerOptionsBase & {
+  version?: 1;
+};
+
+export type CompilerOptions = CompilerOptionsForErgoTreeV0 | CompilerOptionsForErgoTreeV1;
 
 export type NamedConstantsMap = {
   [key: string]: string | ISigmaType | SigmaValue;
 };
 
-export function compile(script: string, options: CompilerOptions = {}): CompilerOutput {
-  const {
-    map = options.map ?? {},
-    segregateConstants = options.segregateConstants ?? true,
-    network = options.network ?? Network.Mainnet,
-    includeSize = options.includeSize ?? true
-  } = options;
+export const compilerDefaults: Required<CompilerOptions> = {
+  version: 1,
+  map: {},
+  segregateConstants: true
+};
 
-  const headerFlags = includeSize ? ergoTreeHeaderFlags.sizeInclusion : 0x00;
-  const tree = constructCompiler(network).compile(
-    parseNamedConstantsMap(map),
-    segregateConstants,
+export function compile(script: string, options?: CompilerOptions): CompilerOutput {
+  const opt = ensureDefaults(options, compilerDefaults);
+  assert(opt.version < 8, `Version should be lower than 8, got ${opt.version}`);
+
+  let headerFlags = 0x00 | opt.version;
+
+  if (opt.version > 0 || (opt.version == 0 && opt.includeSize)) {
+    headerFlags |= ergoTreeHeaderFlags.sizeInclusion;
+  }
+
+  const tree = SigmaCompilerObj.forMainnet().compile(
+    parseNamedConstantsMap(opt.map),
+    opt.segregateConstants,
     headerFlags,
     script
   );
@@ -38,10 +55,18 @@ export function compile(script: string, options: CompilerOptions = {}): Compiler
   return new CompilerOutput(tree);
 }
 
-function constructCompiler(network: Network) {
-  return network === Network.Mainnet
-    ? SigmaCompilerObj.forMainnet()
-    : SigmaCompilerObj.forTestnet();
+function ensureDefaults<T extends object>(
+  options: T | undefined,
+  defaults: Required<T>
+): Required<T> {
+  if (isEmpty(options)) return defaults;
+
+  const newObj: Required<T> = { ...defaults, ...options };
+  for (const key in newObj) {
+    newObj[key] = options[key] ?? defaults[key];
+  }
+
+  return newObj;
 }
 
 export function parseNamedConstantsMap(map: NamedConstantsMap): SigmaCompilerNamedConstantsMap {

--- a/packages/core/src/models/ergoTree.spec.ts
+++ b/packages/core/src/models/ergoTree.spec.ts
@@ -7,7 +7,8 @@ describe("ErgoTree model", () => {
     { tree: "100104c801d191a37300", version: 0, size: false, segregatedConstants: true },
     { tree: "00d191a304c801", version: 0, size: false, segregatedConstants: false },
     { tree: "0806d191a304c801", version: 0, size: true, segregatedConstants: false },
-    { tree: "18090104c801d191a37300", version: 0, size: true, segregatedConstants: true }
+    { tree: "18090104c801d191a37300", version: 0, size: true, segregatedConstants: true },
+    { tree: "19090104c801d191a37300", version: 1, size: true, segregatedConstants: true }
   ])("Should construct from hex ($tree)", (tv) => {
     const tree = new ErgoTree(tv.tree);
 

--- a/packages/mock-chain/src/mockChain.spec.ts
+++ b/packages/mock-chain/src/mockChain.spec.ts
@@ -46,6 +46,23 @@ describe("Mock chain instantiation", () => {
     expect(chain.parties[1]).to.be.equal(alice);
   });
 
+  it("Should clear UTxO set", () => {
+    const chain = new MockChain();
+    const bob = chain
+      .newParty()
+      .withBalance({ nanoergs: 1000000n })
+      .withBalance({ nanoergs: 19827398237n });
+    const alice = chain.newParty().withBalance({ nanoergs: 6000000n });
+
+    expect(bob.utxos).to.have.length(2);
+    expect(alice.utxos).to.have.length(1);
+
+    chain.clearUTxOSet();
+
+    expect(bob.utxos).to.have.length(0);
+    expect(alice.utxos).to.have.length(0);
+  });
+
   it("Should simulate new blocks", () => {
     const blockTime = 120_000;
     const height = 100;

--- a/packages/mock-chain/src/mockChain.spec.ts
+++ b/packages/mock-chain/src/mockChain.spec.ts
@@ -45,6 +45,28 @@ describe("Mock chain instantiation", () => {
     expect(chain.parties).to.have.length(2);
     expect(chain.parties[1]).to.be.equal(alice);
   });
+
+  it("Should simulate new blocks", () => {
+    const blockTime = 120_000;
+    const height = 100;
+    const timestamp = new Date().getTime();
+
+    const chain = new MockChain({ height, timestamp });
+    expect(chain.height).to.be.equal(height);
+    expect(chain.timestamp).to.be.equal(timestamp);
+
+    chain.newBlock(); // +1 block
+    expect(chain.height).to.be.equal(height + 1);
+    expect(chain.timestamp).to.be.equal(timestamp + 1 * blockTime);
+
+    chain.newBlocks(10); // +10 blocks
+    expect(chain.height).to.be.equal(111);
+    expect(chain.timestamp).to.be.equal(timestamp + 11 * blockTime);
+
+    chain.jumpTo(250); // jump to block 250
+    expect(chain.height).to.be.equal(250);
+    expect(chain.timestamp).to.be.equal(timestamp + 150 * blockTime);
+  });
 });
 
 describe("Contract execution and chain mocking", () => {

--- a/packages/mock-chain/src/mockChain.ts
+++ b/packages/mock-chain/src/mockChain.ts
@@ -73,6 +73,10 @@ export class MockChain {
     this._timeStamp += BLOCK_TIME_MS * count;
   }
 
+  jumpTo(newHeight: number) {
+    this.newBlocks(newHeight - this._height);
+  }
+
   newParty(name?: string): MockChainParty;
   newParty(params?: MockChainPartyParams): MockChainParty;
   newParty(nameOrParams?: string | MockChainPartyParams): MockChainParty {

--- a/packages/mock-chain/src/mockChain.ts
+++ b/packages/mock-chain/src/mockChain.ts
@@ -77,6 +77,12 @@ export class MockChain {
     this.newBlocks(newHeight - this._height);
   }
 
+  clearUTxOSet() {
+    for (const party of this._parties) {
+      party.utxos.clear();
+    }
+  }
+
   newParty(name?: string): MockChainParty;
   newParty(params?: MockChainPartyParams): MockChainParty;
   newParty(nameOrParams?: string | MockChainPartyParams): MockChainParty {

--- a/plugins/ageusd/src/exchangePlugin.spec.ts
+++ b/plugins/ageusd/src/exchangePlugin.spec.ts
@@ -29,9 +29,7 @@ describe("AgeUSD exchange plugin, reserve rate under 400%", () => {
   const implementor = chain.newParty("Implementor");
 
   beforeEach(() => {
-    bob.utxos.clear();
-    bankParty.utxos.clear();
-    implementor.utxos.clear();
+    chain.clearUTxOSet();
   });
 
   it("Should mint reserve coin with reserve at 348%", () => {
@@ -415,9 +413,7 @@ describe("AgeUSD exchange plugin, reserve rate between 400% and 800%", () => {
   const implementor = chain.newParty("Implementor");
 
   beforeEach(() => {
-    bob.utxos.clear();
-    bankParty.utxos.clear();
-    implementor.utxos.clear();
+    chain.clearUTxOSet();
   });
 
   it("Should mint reserve coin with reserve at 437%", () => {
@@ -924,9 +920,7 @@ describe("AgeUSD exchange plugin, reserve rate over 800%", () => {
   const implementor = chain.newParty("Implementor");
 
   beforeEach(() => {
-    bob.utxos.clear();
-    bankParty.utxos.clear();
-    implementor.utxos.clear();
+    chain.clearUTxOSet();
   });
 
   it("Should not mint reserve coin with reserve at 918%", () => {

--- a/plugins/ageusd/src/exchangePlugin.spec.ts
+++ b/plugins/ageusd/src/exchangePlugin.spec.ts
@@ -917,7 +917,7 @@ describe("AgeUSD exchange plugin, reserve rate over 800%", () => {
     name: "SigmaUSD Bank",
     ergoTree: SIGMA_USD_PARAMETERS.contract
   });
-  const implementor = chain.newParty("Implementor");
+  chain.newParty("Implementor");
 
   beforeEach(() => {
     chain.clearUTxOSet();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       sigmastate-js:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.2.1
+        version: 0.2.1
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@types/node@20.2.0)(typescript@5.1.6)
@@ -95,8 +95,8 @@ importers:
         specifier: workspace:^
         version: link:../core
       sigmastate-js:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.2.1
+        version: 0.2.1
 
   packages/core:
     dependencies:
@@ -3610,8 +3610,8 @@ packages:
     dependencies:
       '@noble/hashes': 1.3.1
 
-  /sigmastate-js@0.2.0:
-    resolution: {integrity: sha512-nE65AH7IZzro0h7BA4GF+rAIZeXDivLygkuhRKrzLNfOxb3YxuzkPKdvXvA68anN+3uUiE+hHFBLXb5jO08Krw==}
+  /sigmastate-js@0.2.1:
+    resolution: {integrity: sha512-JU/vDIlxdVYc5C4Q/J9ztccSseFcBvy4D3XSYq4jExDAqii1r3umJup83MKha4bVEzz/9hVoIMbhX4Ogi+Cj5w==}
     dependencies:
       '@fleet-sdk/common': 0.1.0-alpha.14
       '@noble/hashes': 1.1.4


### PR DESCRIPTION
- **Compiler**: Set ErgoTree output to v1 by default.
- **MockChain**: Add `MockChain.clearUTxOSet()` method.
- **MockChain**: Add `MockChain.jumpTo()` method.