### PR TITLE
Fix missing types exports

### DIFF
--- a/.changeset/shy-laws-double.md
+++ b/.changeset/shy-laws-double.md
@@ -1,0 +1,11 @@
+---
+"@fleet-sdk/mock-chain": patch
+"@fleet-sdk/serializer": patch
+"@fleet-sdk/compiler": patch
+"@fleet-sdk/common": patch
+"@fleet-sdk/crypto": patch
+"@fleet-sdk/wallet": patch
+"@fleet-sdk/core": patch
+---
+
+Fix missing `types` export in `package.json`

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -6,6 +6,7 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js"
   },
@@ -27,7 +28,6 @@
     "node": ">=14"
   },
   "files": [
-    "src",
     "dist",
     "!**/*.spec.*",
     "!**/*.json",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -6,6 +6,7 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js"
   },
@@ -35,7 +36,6 @@
     "node": ">=14"
   },
   "files": [
-    "src",
     "dist",
     "!**/*.spec.*",
     "!**/*.json",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,6 +6,7 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js"
   },
@@ -34,7 +35,6 @@
     "node": ">=14"
   },
   "files": [
-    "src",
     "dist",
     "!**/*.spec.*",
     "!**/*.json",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -6,6 +6,7 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js"
   },
@@ -33,7 +34,6 @@
     "@scure/base": "^1.1.3"
   },
   "files": [
-    "src",
     "dist",
     "!**/*.spec.*",
     "!**/*.json",

--- a/packages/mock-chain/package.json
+++ b/packages/mock-chain/package.json
@@ -6,6 +6,7 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js"
   },
@@ -40,7 +41,6 @@
     "node": ">=10"
   },
   "files": [
-    "src",
     "dist",
     "!**/*.spec.*",
     "!**/*.json",

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -6,6 +6,7 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js"
   },
@@ -33,7 +34,6 @@
     "node": ">=14"
   },
   "files": [
-    "src",
     "dist",
     "!**/*.spec.*",
     "!**/*.json",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -6,6 +6,7 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js"
   },
@@ -34,7 +35,6 @@
     "node": ">=14"
   },
   "files": [
-    "src",
     "dist",
     "!**/*.spec.*",
     "!**/*.json",


### PR DESCRIPTION
Fix missing `types` export, error:

```
Could not find a declaration file for module '@fleet-sdk/mock-chain'. '/home/ross/Development/machina-finance/node_modules/@fleet-sdk/mock-chain/dist/index.esm.js' implicitly has an 'any' type.
  There are types at '/home/ross/Development/machina-finance/node_modules/@fleet-sdk/mock-chain/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@fleet-sdk/mock-chain' library may need to update its package.json or typings.ts(7016)
  ```
 
  Also remove `src` directory from published packages as it's not needed