### PR TITLE
[CI] Remove tests for `node16`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 18, 20]
+        node-version: [18, 20]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
[Nodejs v16 is deprecated](https://endoflife.date/nodejs), so removing it from CI.