### PR TITLE
Fix types for `SColl[SColl[SByte]]` when passing `UInt8Array`

### DIFF
--- a/.changeset/nasty-beans-count.md
+++ b/.changeset/nasty-beans-count.md
@@ -1,0 +1,5 @@
+---
+"@fleet-sdk/serializer": patch
+---
+
+Fix types for nested `SColl[SBytes]` creation.

--- a/packages/serializer/src/types/constructors.test-d.ts
+++ b/packages/serializer/src/types/constructors.test-d.ts
@@ -124,6 +124,12 @@ describe("Constructor proxies types", () => {
         [false, false]
       ]).data
     ).toMatchTypeOf<boolean[][]>();
+    expectTypeOf(
+      SColl(SColl(SByte), [Uint8Array.from([1, 2, 3]), Uint8Array.from([4, 5, 6])]).data
+    ).toMatchTypeOf<Uint8Array[]>();
+    expectTypeOf(SColl(SColl(SByte), ["deadbeef", "cafe"]).data).toMatchTypeOf<
+      Uint8Array[]
+    >();
 
     expectTypeOf(SPair(SInt(1), SBool(false)).data).toMatchTypeOf<[number, boolean]>();
     expectTypeOf(SPair(SBool(true), SInt(1)).data).toMatchTypeOf<[boolean, number]>();

--- a/packages/serializer/src/types/constructors.ts
+++ b/packages/serializer/src/types/constructors.ts
@@ -112,11 +112,16 @@ type SUnit = (value?: undefined) => SConstant<undefined, SUnitType>;
 export const SUnit: SUnit = monoProxy(SUnitType, undefined, true);
 
 type SColl = {
-  <D, T extends SType>(type: SConstructor<D, T>): SConstructor<D[], T>;
   <D, T extends SByteType>(
     type: SConstructor<D, T>,
     elements: ByteInput | D[]
   ): SConstant<Uint8Array, T>;
+  <D, T extends SByteType>(
+    type: SConstructor<D, T>,
+    elements: ByteInput[]
+  ): SConstant<Uint8Array[], T>;
+
+  <D, T extends SType>(type: SConstructor<D, T>): SConstructor<D[], T>;
   <D, T extends SType>(type: SConstructor<D, T>, elements: D[]): SConstant<D[], T>;
 };
 


### PR DESCRIPTION
Fixes #152